### PR TITLE
chore(deps): update stable image quay.io/konflux-ci/release-service-utils to 2243945e96beb0f26125a68fec7fa55b6791463ec1bdf62dcf6a003a36bd0959

### DIFF
--- a/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -68,7 +68,7 @@ spec:
                   export -f deleteAndLog
                   xargs -a ${PRUNING_CRS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
               imagePullPolicy: IfNotPresent
-              image: quay.io/konflux-ci/release-service-utils@sha256:2d9e07584dd9510d14c48390bd0b080ed6ff44edca2c43c704cdbc5c82a2f99d
+              image: quay.io/konflux-ci/release-service-utils@sha256:2243945e96beb0f26125a68fec7fa55b6791463ec1bdf62dcf6a003a36bd0959
               volumeMounts:
                 - mountPath: /var/tmp
                   name: temp-directory


### PR DESCRIPTION
This PR updates the image quay.io/konflux-ci/release-service-utils from 2d9e07584dd9510d14c48390bd0b080ed6ff44edca2c43c704cdbc5c82a2f99d to 2243945e96beb0f26125a68fec7fa55b6791463ec1bdf62dcf6a003a36bd0959 /n Signed-off-by: Sean Conroy <sconroy@redhat.com>