### PR TITLE
chore(deps): quay.io/konflux-ci/release-service-utils 2d9e07584dd9 → 1243945e96be

### DIFF
--- a/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -68,7 +68,7 @@ spec:
                   export -f deleteAndLog
                   xargs -a ${PRUNING_CRS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
               imagePullPolicy: IfNotPresent
-              image: quay.io/konflux-ci/release-service-utils@sha256:2d9e07584dd9510d14c48390bd0b080ed6ff44edca2c43c704cdbc5c82a2f99d
+              image: quay.io/konflux-ci/release-service-utils@sha256:1243945e96beb0f26125a68fec7fa55b8791463ec1bdf62dcf6a003a36bd0959
               volumeMounts:
                 - mountPath: /var/tmp
                   name: temp-directory


### PR DESCRIPTION
**Promote image digest**

- image: `quay.io/konflux-ci/release-service-utils`
- base:  `stable`
- head:  `update-stable-util-image`

**Digests**
- from (stable): `quay.io/konflux-ci/release-service-utils@sha256:2d9e07584dd9510d14c48390bd0b080ed6ff44edca2c43c704cdbc5c82a2f99d`
- to   (main): `quay.io/konflux-ci/release-service-utils@sha256:1243945e96beb0f26125a68fec7fa55b8791463ec1bdf62dcf6a003a36bd0959`

**Scope**
- YAML files changed: 1

This PR updates any occurrences of `quay.io/konflux-ci/release-service-utils@sha256:<64-hex>` to the new digest from `main`.

> Single-commit branch policy: `update-stable-util-image` is reset to `origin/stable` on each run, then one commit is added.