### PR TITLE
chore(deps): bump quay.io/konflux-ci/release-service-utils from `6bd0959` to `6bd0959`

### DIFF
--- a/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -68,7 +68,7 @@ spec:
                   export -f deleteAndLog
                   xargs -a ${PRUNING_CRS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
               imagePullPolicy: IfNotPresent
-              image: quay.io/konflux-ci/release-service-utils@sha256:2253945e96beb0f26125a68fec7fa55b8791463ec1bdf62dcf6a003a36bd0959
+              image: quay.io/konflux-ci/release-service-utils@sha256:1243945e96beb0f26125a68fec7fa55b8791463ec1bdf62dcf6a003a36bd0959
               volumeMounts:
                 - mountPath: /var/tmp
                   name: temp-directory


### PR DESCRIPTION
Promote `quay.io/konflux-ci/release-service-utils` digest on `stable`.

- source (`main`): `quay.io/konflux-ci/release-service-utils@sha256:1243945e96beb0f26125a68fec7fa55b8791463ec1bdf62dcf6a003a36bd0959`
- target (`stable`): `quay.io/konflux-ci/release-service-utils@sha256:2253945e96beb0f26125a68fec7fa55b8791463ec1bdf62dcf6a003a36bd0959`
- files changed (1):
  - internal-services/config/cronjob/cleanup-internal-requests-pipelineruns.yaml